### PR TITLE
serialization: use buffer to serialize for net support

### DIFF
--- a/script/test
+++ b/script/test
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -ex
 
 for it in test/*.test.js; do
   iotjs $it

--- a/test/net.test.js
+++ b/test/net.test.js
@@ -1,0 +1,28 @@
+var net = require('net')
+var assert = require('assert')
+var Caps = require('../').Caps
+
+var server = net.createServer((socket) => {
+  var bufs = []
+  socket.on('data', data => {
+    bufs.push(data)
+  })
+  socket.on('end', () => {
+    var data = Buffer.concat(bufs)
+    var caps = new Caps()
+    caps.deserialize(data)
+    assert(caps.readString(), 'foo')
+    socket.end()
+    server.close()
+  })
+})
+server.listen(0, () => {
+  var port = server.address().port
+  var cli = net.connect(port, '127.0.0.1', () => {
+    var caps = new Caps()
+    caps.writeString('foo')
+    var data = caps.serialize()
+    cli.write(data)
+    cli.end()
+  })
+})


### PR DESCRIPTION
UInt8Array is not properly supported in ShadowNode (until v0.11.x)